### PR TITLE
Add position sizing module and integrate with signal generation

### DIFF
--- a/MILESTONES_ISSUES.csv
+++ b/MILESTONES_ISSUES.csv
@@ -8,6 +8,7 @@ Atualização diária automática,Job agendado para atualizar dados.,"automation
 Implementar RSI + MACD + EMAs,Gerar colunas de indicadores no dataset.,strategy,M3 - Estratégia Base Swing Trade
 Regras de entrada/saída,Definir sinais a partir dos indicadores.,strategy,M3 - Estratégia Base Swing Trade
 Função de geração de sinais,Consolidar sinais em DataFrame final.,strategy,M3 - Estratégia Base Swing Trade
+Regras de position sizing e limites de perda,Definir dimensionamento das posições e limites de perda.,strategy,M3 - Estratégia Base Swing Trade
 Módulo de backtesting,Simular operações com custos e slippage simples.,backtesting,M4 - Backtesting Inicial
 Relatório de métricas,"Exportar retorno, drawdown e hit ratio.",report,M4 - Backtesting Inicial
 Comparação com IBOV,Benchmark buy & hold do IBOV vs estratégia.,analysis,M4 - Backtesting Inicial

--- a/swing_trade/__init__.py
+++ b/swing_trade/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for swing trade utilities."""

--- a/swing_trade/position_sizing.py
+++ b/swing_trade/position_sizing.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class PositionSizingConfig:
+    """Configuration for position sizing rules.
+
+    Attributes:
+        capital: Total trading capital available.
+        risk_per_trade: Fraction of capital to risk per trade (e.g., 0.02 for 2%).
+    """
+
+    capital: float
+    risk_per_trade: float
+
+
+def stop_loss_price(entry_price: float, stop_loss_pct: float) -> float:
+    """Calculate absolute stop loss price given an entry price and percentage.
+
+    Args:
+        entry_price: Price where the position is opened.
+        stop_loss_pct: Stop loss percentage expressed as decimal (0.02 == 2%).
+
+    Returns:
+        Price level for the stop loss.
+    """
+    return entry_price * (1 - stop_loss_pct)
+
+
+def calculate_position_size(
+    config: PositionSizingConfig, entry_price: float, stop_loss_price: float
+) -> int:
+    """Calculate quantity of shares to trade based on risk parameters.
+
+    Args:
+        config: Position sizing configuration.
+        entry_price: Price where the position is opened.
+        stop_loss_price: Price where the trade will be exited if it goes against us.
+
+    Returns:
+        Integer number of shares to trade.
+
+    Raises:
+        ValueError: If the stop loss is not below the entry price.
+    """
+    risk_amount = config.capital * config.risk_per_trade
+    risk_per_share = entry_price - stop_loss_price
+    if risk_per_share <= 0:
+        raise ValueError("Stop loss must be below entry price")
+    return int(risk_amount / risk_per_share)

--- a/swing_trade/signals.py
+++ b/swing_trade/signals.py
@@ -1,0 +1,49 @@
+from statistics import mean
+from typing import List
+
+from .position_sizing import (
+    PositionSizingConfig,
+    calculate_position_size,
+    stop_loss_price,
+)
+
+
+def generate_signal_with_position(
+    prices: List[float],
+    config: PositionSizingConfig,
+    stop_loss_pct: float,
+) -> dict:
+    """Generate trading signal and position size based on price history.
+
+    The signal is ``buy`` when the last price is above the simple moving average
+    of the last five prices; otherwise ``sell``. For buy signals the function
+    calculates position size and stop loss price.
+
+    Args:
+        prices: Historical closing prices ordered from oldest to newest.
+        config: Position sizing configuration.
+        stop_loss_pct: Percentage used to compute the stop loss for buys.
+
+    Returns:
+        Dictionary with signal information including position size and stop loss.
+    """
+    if len(prices) < 5:
+        raise ValueError("At least five prices are required to generate a signal")
+
+    last_price = prices[-1]
+    sma = mean(prices[-5:])
+    signal = "buy" if last_price > sma else "sell"
+
+    if signal == "buy":
+        sl_price = stop_loss_price(last_price, stop_loss_pct)
+        size = calculate_position_size(config, last_price, sl_price)
+    else:
+        sl_price = None
+        size = 0
+
+    return {
+        "signal": signal,
+        "entry_price": last_price,
+        "stop_loss": sl_price,
+        "position_size": size,
+    }

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pytest
+from swing_trade.position_sizing import PositionSizingConfig, calculate_position_size
+from swing_trade.signals import generate_signal_with_position
+
+
+def test_calculate_position_size():
+    config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
+    entry = 100.0
+    stop = 95.0
+    assert calculate_position_size(config, entry, stop) == 40
+
+
+def test_generate_signal_with_position_buy():
+    prices = [100, 101, 102, 103, 104, 105]
+    config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
+    result = generate_signal_with_position(prices, config, 0.02)
+    assert result["signal"] == "buy"
+    assert result["position_size"] == 95
+    assert result["stop_loss"] == pytest.approx(102.9)
+
+
+def test_generate_signal_with_position_sell():
+    prices = [105, 104, 103, 102, 101, 100]
+    config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
+    result = generate_signal_with_position(prices, config, 0.02)
+    assert result["signal"] == "sell"
+    assert result["position_size"] == 0
+    assert result["stop_loss"] is None


### PR DESCRIPTION
## Summary
- implement position sizing rules and stop-loss calculations
- integrate position sizing with signal generation
- track position sizing task in `M3 - Estratégia Base Swing Trade`

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4176f14e48326aafd6df95a954378