### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/MILESTONES_ISSUES.csv
+++ b/MILESTONES_ISSUES.csv
@@ -26,6 +26,7 @@ Log de ordens simuladas,Persistir ordens e resultados.,logging,M8 - Paper Tradin
 Dashboard local (Streamlit/Grafana),Métricas de execução e erros.,monitoring,M9 - Observabilidade Básica
 Log estruturado,"JSON logs com contexto (execução, erros).",logging,M9 - Observabilidade Básica
 Alerta de falha de job,Notificar quando job diário falhar.,alerts,M9 - Observabilidade Básica
+Instrumentar métricas de CPU/memória/latência,Expor métricas via Prometheus.,monitoring,M9 - Observabilidade Básica
 Gerenciar secrets com .env/Secrets,Variáveis seguras fora do repo.,security,M10 - Segurança e Compliance
 Controle de acesso ao bot,Restringir uso e abuso de API/alertas.,security,M10 - Segurança e Compliance
 Política de uso seguro,Documentar práticas de segurança.,"docs,security",M10 - Segurança e Compliance

--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@ Objetivo principal
 
 Automatizar operações de Swing Trade na B3 (Bolsa de Valores do Brasil) usando dados históricos e indicadores técnicos para gerar sinais de compra e venda, testar estratégias e acompanhar resultados.
 
-
 Status: aguardando desenvolvimento
+
+## Observabilidade
+
+Aplicação FastAPI instrumentada com métricas de CPU, memória e latência expostas no endpoint `/metrics` para coleta via Prometheus.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
+from prometheus_client import CollectorRegistry, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
+import psutil
+import time
+
+app = FastAPI()
+registry = CollectorRegistry()
+
+# Metrics
+REQUEST_LATENCY = Histogram(
+    "request_latency_seconds", "Request latency in seconds",
+    ["method", "endpoint"], registry=registry
+)
+CPU_USAGE = Gauge(
+    "process_cpu_percent", "Process CPU usage percent", registry=registry
+)
+MEMORY_USAGE = Gauge(
+    "process_memory_bytes", "Process memory usage in bytes", registry=registry
+)
+
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):
+    start_time = time.perf_counter()
+    response = await call_next(request)
+    latency = time.perf_counter() - start_time
+    REQUEST_LATENCY.labels(request.method, request.url.path).observe(latency)
+    # Update CPU and memory after each request
+    process = psutil.Process()
+    CPU_USAGE.set(process.cpu_percent())
+    MEMORY_USAGE.set(process.memory_info().rss)
+    return response
+
+@app.get("/metrics")
+async def metrics():
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)
+
+@app.get("/")
+async def read_root():
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+prometheus-client
+psutil


### PR DESCRIPTION
## Summary
- instrument FastAPI app to expose CPU, memory, and latency metrics via Prometheus
- add dependencies for observability
- track observability issue in milestone list

## Testing
- `python -m py_compile app/main.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4177e972083269e54882adddd591f