### PR TITLE
Streamline test imports by installing package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -e .
           pip install pre-commit pytest
       - name: Run pre-commit
         run: pre-commit run --all-files
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Após clonar o repositório, instale-as executando:
 poetry install
 ```
 
+Como alternativa, o projeto pode ser instalado em modo editável com `pip`:
+
+```bash
+pip install -e .
+```
+
 Para gerar um arquivo `requirements.txt` compatível com `pip`, utilize:
 
 ```bash
@@ -32,6 +38,14 @@ poetry run uvicorn app.main:app --reload
 Para rodar os testes:
 
 ```bash
+pip install -e .
+pytest
+```
+
+Ou utilizando Poetry:
+
+```bash
+poetry install
 poetry run pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "swing-trade-b3"
 version = "0.1.0"
 description = "Automatiza operações de Swing Trade na B3"
 authors = ["Contributors <email@example.com>"]
+packages = [{ include = "swing_trade" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1,6 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 import pytest
 from swing_trade.position_sizing import PositionSizingConfig, calculate_position_size
 from swing_trade.signals import generate_signal_with_position


### PR DESCRIPTION
## Summary
- remove manual `sys.path` modification in tests
- configure Poetry to include `swing_trade` package
- install package and run tests in CI, update docs for editable install

## Testing
- `pre-commit run --files tests/test_trading.py README.md .github/workflows/ci.yml pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4ee26008326ada78b6c82987ada