### PR TITLE
feat: return typed trade signal

### DIFF
--- a/swing_trade/signals.py
+++ b/swing_trade/signals.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from statistics import mean
-from typing import List
+from typing import List, Optional
 
 from .position_sizing import (
     PositionSizingConfig,
@@ -8,11 +9,21 @@ from .position_sizing import (
 )
 
 
+@dataclass
+class TradeSignal:
+    """Typed representation of the generated trading signal."""
+
+    signal: str
+    entry_price: float
+    stop_loss: Optional[float]
+    position_size: int
+
+
 def generate_signal_with_position(
     prices: List[float],
     config: PositionSizingConfig,
     stop_loss_pct: float,
-) -> dict:
+) -> TradeSignal:
     """Generate trading signal and position size based on price history.
 
     The signal is ``buy`` when the last price is above the simple moving average
@@ -25,7 +36,8 @@ def generate_signal_with_position(
         stop_loss_pct: Percentage used to compute the stop loss for buys.
 
     Returns:
-        Dictionary with signal information including position size and stop loss.
+        ``TradeSignal`` containing signal information including position size and
+        stop loss.
     """
     if len(prices) < 5:
         raise ValueError("At least five prices are required to generate a signal")
@@ -41,9 +53,9 @@ def generate_signal_with_position(
         sl_price = None
         size = 0
 
-    return {
-        "signal": signal,
-        "entry_price": last_price,
-        "stop_loss": sl_price,
-        "position_size": size,
-    }
+    return TradeSignal(
+        signal=signal,
+        entry_price=last_price,
+        stop_loss=sl_price,
+        position_size=size,
+    )

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1,9 +1,11 @@
 import sys
 from pathlib import Path
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import pytest
 from swing_trade.position_sizing import PositionSizingConfig, calculate_position_size
-from swing_trade.signals import generate_signal_with_position
+from swing_trade.signals import TradeSignal, generate_signal_with_position
 
 
 def test_calculate_position_size():
@@ -17,15 +19,17 @@ def test_generate_signal_with_position_buy():
     prices = [100, 101, 102, 103, 104, 105]
     config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
     result = generate_signal_with_position(prices, config, 0.02)
-    assert result["signal"] == "buy"
-    assert result["position_size"] == 95
-    assert result["stop_loss"] == pytest.approx(102.9)
+    assert isinstance(result, TradeSignal)
+    assert result.signal == "buy"
+    assert result.position_size == 95
+    assert result.stop_loss == pytest.approx(102.9)
 
 
 def test_generate_signal_with_position_sell():
     prices = [105, 104, 103, 102, 101, 100]
     config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
     result = generate_signal_with_position(prices, config, 0.02)
-    assert result["signal"] == "sell"
-    assert result["position_size"] == 0
-    assert result["stop_loss"] is None
+    assert isinstance(result, TradeSignal)
+    assert result.signal == "sell"
+    assert result.position_size == 0
+    assert result.stop_loss is None


### PR DESCRIPTION
## Summary
- introduce `TradeSignal` dataclass to represent generated signals
- update `generate_signal_with_position` to return `TradeSignal`
- adjust tests for new typed return

## Testing
- `pre-commit run --files swing_trade/signals.py tests/test_trading.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f4f6787c83269e27b77e7a970939