### PR TITLE
Reuse psutil process for metrics middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,8 @@ from prometheus_client import CollectorRegistry, Gauge, Histogram, generate_late
 import psutil
 import time
 
+process = psutil.Process()
+
 app = FastAPI()
 registry = CollectorRegistry()
 
@@ -26,7 +28,6 @@ async def metrics_middleware(request: Request, call_next):
     latency = time.perf_counter() - start_time
     REQUEST_LATENCY.labels(request.method, request.url.path).observe(latency)
     # Update CPU and memory after each request
-    process = psutil.Process()
     CPU_USAGE.set(process.cpu_percent())
     MEMORY_USAGE.set(process.memory_info().rss)
     return response

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import re
+import psutil
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_metrics_report_process_info():
+    client.get("/")
+    client.get("/")
+    expected_mem = psutil.Process().memory_info().rss
+
+    metrics_response = client.get("/metrics")
+    assert metrics_response.status_code == 200
+    metrics_text = metrics_response.text
+
+    mem_match = re.search(r"^process_memory_bytes\s+([0-9.e+-]+)", metrics_text, re.MULTILINE)
+    cpu_match = re.search(r"^process_cpu_percent\s+([0-9.e+-]+)", metrics_text, re.MULTILINE)
+
+    assert mem_match is not None
+    assert cpu_match is not None
+
+    memory_metric = float(mem_match.group(1))
+    cpu_metric = float(cpu_match.group(1))
+
+    assert abs(memory_metric - expected_mem) < 10_000_000  # 10 MB tolerance
+    assert cpu_metric >= 0


### PR DESCRIPTION
## Summary
- create module-level psutil process
- reuse shared process in metrics middleware
- test metrics endpoint for accurate CPU and memory reporting

## Testing
- `pre-commit run --files app/main.py tests/test_metrics.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f50487748326889362443d2a3c83