### PR TITLE
Remove test override in pre-commit pytest hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: bash -c "pytest || true"
+        entry: bash -c "pytest"
         language: system
         pass_filenames: false


### PR DESCRIPTION
## Summary
- remove `|| true` from pytest pre-commit hook so test failures block commits

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6f51000788326bdcdd76ac6927276