### PR TITLE
docs: add license section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ poetry run pytest
 ## Observabilidade
 
 Aplicação FastAPI instrumentada com métricas de CPU, memória e latência expostas no endpoint `/metrics` para coleta via Prometheus.
+
+## Licença
+
+Este projeto é licenciado sob os termos da licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.


### PR DESCRIPTION
## Summary
- document project licensing

## Testing
- `pre-commit run --files README.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b29384f11c832682939e98d44bf17a