### PR TITLE
chore(pkg): expose version and test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Automatiza operações de Swing Trade na B3"
 authors = ["Contributors <email@example.com>"]
 license = "MIT"
 packages = [{ include = "swing_trade" }]
+readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/swing_trade/__init__.py
+++ b/swing_trade/__init__.py
@@ -1,1 +1,13 @@
-"""Core package for swing trade utilities."""
+"""Core package for swing trade utilities.
+
+This module exposes package metadata such as ``__version__`` to
+consumers. Keeping the version in code helps validate that the
+installation via Poetry is working correctly.
+"""
+
+__all__ = ["__version__"]
+
+# The project version is defined here to allow runtime inspection.
+# It should mirror the version specified in ``pyproject.toml``.
+__version__ = "0.1.0"
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,11 @@
+import tomllib
+from pathlib import Path
+
+from swing_trade import __version__
+
+
+def test_version_matches_pyproject():
+    """Ensure package version matches configuration."""
+    data = tomllib.loads(Path("pyproject.toml").read_text())
+    expected = data["tool"]["poetry"]["version"]
+    assert __version__ == expected


### PR DESCRIPTION
## Summary
- expose `__version__` constant in core package
- include README in Poetry metadata
- add test ensuring package version matches `pyproject.toml`

## Testing
- `poetry run pre-commit run --files swing_trade/__init__.py pyproject.toml tests/test_version.py`
- `poetry run pytest`

Closes #1

------
https://chatgpt.com/codex/tasks/task_e_68b2acb3f1148326b9daeb786a75dab3