### PR TITLE
docs: update architecture and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,13 @@ O sistema é dividido em módulos independentes que tratam coleta de dados, gera
 
 ```mermaid
 flowchart LR
-  A["Fontes de dados\nyfinance/brapi/B3"] --> B["Ingestão & Preparação"]
-  B --> C["Estratégias\nSinais"]
+  A[Fontes de dados<br/>yfinance/brapi/B3] --> B[Ingestão & Preparação]
+  B --> C[Estratégias<br/>Sinais]
   C --> D[Backtesting]
-  C --> E["API FastAPI"]
-  D --> F["Relatórios/Resultados"]
-  E --> G["Notificações\ne-mail/Telegram"]
+  C --> E[API FastAPI]
+  D --> F[Relatórios/Resultados]
+  E --> G[Notificações<br/>(e-mail/Telegram)]
 ```
-
-![Arquitetura](docs/arch.svg)
 
 ## Estrutura do Projeto
 
@@ -155,22 +153,14 @@ make test
 ```
 
 ## Observabilidade
+- **Healthcheck:** `GET /healthz` → `{"status":"ok"}`
+- **Métricas Prometheus:** `GET /metrics` (OpenMetrics)
 
-A aplicação FastAPI expõe endpoints de observabilidade:
-
-- **Healthcheck:** `GET /healthz` → `{"status": "ok"}`
-- **Métricas Prometheus:** `GET /metrics` (OpenMetrics; scrape por Prometheus/Grafana Agent)
-
-### Teste rápido (local)
+Teste rápido:
 ```bash
-# saúde geral
 curl -fsS http://localhost:8000/healthz | jq .
-
-# primeiras linhas das métricas
 curl -fsS http://localhost:8000/metrics | head -n 20
 ```
-
-As métricas incluem CPU, memória e latência HTTP. Em produção, configure o scrape do Prometheus para `http://<host>:<port>/metrics`.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- use native Mermaid flowchart for architecture diagram
- streamline observability section with health and metrics example

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b2cf61da4483269943c684bd603418