### PR TITLE
test: cover health and metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ A aplicação FastAPI expõe endpoints de observabilidade:
 - **Healthcheck:** `GET /healthz` → `{"status": "ok"}`
 - **Métricas Prometheus:** `GET /metrics` (OpenMetrics; scrape por Prometheus/Grafana Agent)
 
+Ambos os endpoints possuem testes automatizados garantindo resposta `200 OK` e formato compatível com o Prometheus, evitando regressões.
+
 ### Teste rápido (local)
 ```bash
 # saúde geral

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,8 @@
 import re
+
 import psutil
 from fastapi.testclient import TestClient
+from prometheus_client import CONTENT_TYPE_LATEST
 
 from app.main import app
 
@@ -13,7 +15,14 @@ def test_metrics_report_process_info() -> None:
 
     metrics_response = client.get("/metrics")
     assert metrics_response.status_code == 200
+    assert metrics_response.headers["content-type"] == CONTENT_TYPE_LATEST
     metrics_text = metrics_response.text
+
+    assert metrics_text.startswith("# HELP")
+    assert "# HELP process_cpu_percent" in metrics_text
+    assert "# TYPE process_cpu_percent gauge" in metrics_text
+    assert "# HELP process_memory_bytes" in metrics_text
+    assert "# TYPE process_memory_bytes gauge" in metrics_text
 
     mem_match = re.search(
         r"^process_memory_bytes\s+([0-9.e+-]+)", metrics_text, re.MULTILINE


### PR DESCRIPTION
## Summary
- verify `/metrics` returns Prometheus headers and `# HELP/# TYPE` prefixes
- document that observability endpoints are covered by tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf6e706c8326ab97c7422adf5cfe