### PR TITLE
Add position sizing tests and observability enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           poetry install --with dev
       - name: Ruff and Black
         run: |
-          poetry run ruff .
+          poetry run ruff check .
           poetry run black --check .
   typecheck:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
           pip install poetry
           poetry install --with dev
       - name: Mypy
-        run: poetry run mypy .
+        run: poetry run mypy --strict .
   test:
     runs-on: ubuntu-latest
     needs: typecheck

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ git clone https://github.com/leotavo/swing-trade-b3 && cd swing-trade-b3
 poetry install && cp -n .env.example .env || true
 poetry run uvicorn app.main:app --reload
 # smoke-test
-curl -fsS http://localhost:8000/docs >/dev/null && echo "API OK"
+curl -fsS http://localhost:8000/healthz | jq .
+curl -I http://localhost:8000/metrics | head -n 1
 ```
 
 > Automatizar operações de Swing Trade na B3 (Bolsa de Valores do Brasil) usando dados históricos e indicadores técnicos para gerar sinais de compra e venda, testar estratégias e acompanhar resultados.
@@ -167,7 +168,7 @@ make test
 A aplicação FastAPI expõe endpoints de observabilidade:
 
 - **Healthcheck:** `GET /healthz` → `{"status": "ok"}`
-- **Métricas Prometheus:** `GET /metrics` (OpenMetrics; scrape por Prometheus/Grafana Agent)
+- **Métricas Prometheus:** `GET /metrics` (OpenMetrics; responde `Content-Type: text/plain; version=0.0.4` e inclui linhas `# HELP`)
 
 Ambos os endpoints possuem testes automatizados garantindo resposta `200 OK` e formato compatível com o Prometheus, evitando regressões.
 
@@ -175,6 +176,7 @@ Ambos os endpoints possuem testes automatizados garantindo resposta `200 OK` e f
 
 ```bash
 curl -fsS http://localhost:8000/healthz | jq .
+curl -I http://localhost:8000/metrics | head -n 1
 curl -fsS http://localhost:8000/metrics | head -n 20
 ```
 

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -52,9 +52,19 @@ async def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@router.head("/healthz")
+async def healthz_head() -> Response:
+    return Response(status_code=200)
+
+
 @router.get("/metrics")
 async def metrics() -> Response:
     return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)
+
+
+@router.head("/metrics")
+async def metrics_head() -> Response:
+    return Response(media_type=CONTENT_TYPE_LATEST)
 
 
 def setup(app: FastAPI) -> None:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -9,3 +9,8 @@ def test_healthz() -> None:
     response = client.get("/healthz")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_healthz_head() -> None:
+    response = client.head("/healthz")
+    assert response.status_code == 200

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,3 +39,9 @@ def test_metrics_report_process_info() -> None:
 
     assert abs(memory_metric - expected_mem) < 10_000_000  # 10 MB tolerance
     assert cpu_metric >= 0
+
+
+def test_metrics_head() -> None:
+    response = client.head("/metrics")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == CONTENT_TYPE_LATEST

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -1,0 +1,23 @@
+import pytest
+from swing_trade.position_sizing import (
+    PositionSizingConfig,
+    calculate_position_size,
+    stop_loss_price,
+)
+
+
+def test_calculate_position_size_basic() -> None:
+    config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
+    entry = 100.0
+    stop = 95.0
+    assert calculate_position_size(config, entry, stop) == 40
+
+
+def test_calculate_position_size_invalid_stop() -> None:
+    config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
+    with pytest.raises(ValueError):
+        calculate_position_size(config, 100.0, 100.0)
+
+
+def test_stop_loss_price() -> None:
+    assert stop_loss_price(100.0, 0.05) == 95.0

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -33,13 +33,13 @@ def test_generate_signal_with_position_sell() -> None:
     assert result.stop_loss is None
 
 
-@pytest.mark.parametrize("pct", [0.0, -0.01])  # type: ignore[misc]
+@pytest.mark.parametrize("pct", [0.0, -0.01])
 def test_stop_loss_price_invalid_pct(pct: float) -> None:
     with pytest.raises(ValueError):
         stop_loss_price(100.0, pct)
 
 
-@pytest.mark.parametrize("pct", [0.0, -0.01])  # type: ignore[misc]
+@pytest.mark.parametrize("pct", [0.0, -0.01])
 def test_generate_signal_with_position_invalid_pct(pct: float) -> None:
     prices = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0]
     config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)


### PR DESCRIPTION
## Summary
- add tests for position sizing, including invalid stop handling
- support HEAD requests for /healthz and /metrics endpoints
- document smoke tests and enforce stricter CI (ruff, black, mypy --strict, pytest --cov)

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run mypy --strict .`
- `poetry run pytest --cov=app --cov=swing_trade --cov-report=term-missing -q`
- `curl -fsS http://localhost:8000/healthz`
- `curl -I http://localhost:8000/metrics | head -n 20`
- `curl -fsS http://localhost:8000/metrics | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68b2d52e599c8326a5f9381c8128c79a