### PR TITLE
fix: satisfy mypy in trading tests

### DIFF
--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -33,15 +33,15 @@ def test_generate_signal_with_position_sell() -> None:
     assert result.stop_loss is None
 
 
-@pytest.mark.parametrize("pct", [0.0, -0.01])
-def test_stop_loss_price_invalid_pct(pct: float) -> None:
-    with pytest.raises(ValueError):
-        stop_loss_price(100.0, pct)
+def test_stop_loss_price_invalid_pct() -> None:
+    for pct in (0.0, -0.01):
+        with pytest.raises(ValueError):
+            stop_loss_price(100.0, pct)
 
 
-@pytest.mark.parametrize("pct", [0.0, -0.01])
-def test_generate_signal_with_position_invalid_pct(pct: float) -> None:
+def test_generate_signal_with_position_invalid_pct() -> None:
     prices = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0]
     config = PositionSizingConfig(capital=10_000, risk_per_trade=0.02)
-    with pytest.raises(ValueError):
-        generate_signal_with_position(prices, config, pct)
+    for pct in (0.0, -0.01):
+        with pytest.raises(ValueError):
+            generate_signal_with_position(prices, config, pct)


### PR DESCRIPTION
## Summary
- refactor tests to avoid untyped pytest decorator

## Testing
- `pre-commit run --all-files`
- `pytest --cov=app --cov=swing_trade`
- `curl -fsS http://localhost:8000/healthz`
- `curl -I http://localhost:8000/metrics`
- `curl -fsS http://localhost:8000/metrics | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68b2d701f4f483269fd09d389df44880