### PR TITLE
ci: enforce branch naming

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,0 +1,21 @@
+name: Branch name
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  branch-name:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          if [[ ! "$branch" =~ ^(feat|fix|docs)/ ]]; then
+            echo "Invalid branch name: $branch"
+            echo "Branch names must start with 'feat/', 'fix/', or 'docs/'."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ poetry install
   - `fix/` para correções de bugs
   - `docs/` para ajustes de documentação
 - Abra Pull Requests para unir alterações em `main`. Solicite revisão antes de fazer o merge.
+- Os nomes de branch são validados automaticamente via CI e devem seguir o padrão acima.
 
 ## Padrões de Commit
 - Utilize o padrão [Conventional Commits](https://www.conventionalcommits.org/).

--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ make lint
 Confira [TECH_STACK.md](TECH_STACK.md).
 
 ## Contribuindo
-Leia o [CONTRIBUTING.md](CONTRIBUTING.md) e siga _Conventional Commits_.  
+Leia o [CONTRIBUTING.md](CONTRIBUTING.md) e siga _Conventional Commits_.
 PRs com testes e atualização de docs quando aplicável.
+Branches devem seguir `feat/`, `fix/` ou `docs/` e são verificadas automaticamente no CI.
 
 ## Comunidade e Suporte
 - Código de Conduta: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## Summary
- enforce branch naming via new workflow
- document automatic branch-name check in contributing guide and README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b3421b44848326b44a7d9a94dfbbc4