### PR TITLE
docs: document pre-commit usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ poetry install
 - Escreva mensagens curtas e no imperativo.
 
 ## Testes e Qualidade
-- Execute os testes e linters antes de enviar um PR:
+- Execute os linters e testes antes de enviar um PR:
   ```bash
-  ruff check .
+  pre-commit run --files <arquivos_modificados>
   pytest
   ```
 - Garanta que todos os testes estejam passando e que o código siga as regras de estilo.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ make test
 make typecheck
 make lint
 ```
+Para um lint rápido apenas nos arquivos modificados, utilize `pre-commit run --files <arquivos_modificados>`.
+
 - Meta de cobertura: **≥ 80% (alerta se abaixo)**
 - Estilo: **ruff + black**
 - Tipagem: **mypy (strict)**


### PR DESCRIPTION
## Summary
- document running pre-commit on modified files in README
- add pre-commit invocation to contribution guide

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b34149e8108326a6ee2faeada7dd50