### PR TITLE
docs: rename Agents instructions file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Agents.md - Swing Trade B3
+# AGENTS.md - Swing Trade B3
 
 > **Instrução:** Sempre que o projeto for atualizado, revise e atualize o README.md para refletir as mudanças.
 > **Branches:** Devem começar com `feat/`, `fix/` ou `docs/`; a verificação acontece no CI e falhará para nomes inválidos. O Codex também deve usar esses prefixos ao criar branches.
@@ -8,7 +8,7 @@ Gerado automaticamente a partir de **milestones** e **issues** do repositório l
 
 ## Índice
 
-- [Agents.md - Swing Trade B3](#agentsmd---swing-trade-b3)
+- [AGENTS.md - Swing Trade B3](#agentsmd---swing-trade-b3)
   - [Índice](#índice)
   - [M1 - Configuração Inicial](#m1---configuração-inicial)
   - [M2 - Coleta e Preparação de Dados](#m2---coleta-e-preparação-de-dados)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ poetry install
 - Escreva mensagens curtas e no imperativo.
 
 ## Testes e Qualidade
-- Execute os testes e linters antes de enviar um PR:
+- Execute os linters e testes antes de enviar um PR:
   ```bash
-  ruff check .
+  pre-commit run --files <arquivos_modificados>
   pytest
   ```
 - Garanta que todos os testes estejam passando e que o código siga as regras de estilo.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ flowchart LR
 ├── swing_trade/     # Núcleo: dados, indicadores, sinais, backtesting
 ├── tests/           # Testes automatizados
 ├── README.md        # Documentação principal
-└── Agents.md        # Roadmap e instruções operacionais
+└── AGENTS.md        # Roadmap e instruções operacionais
 ```
 
 ## Como Começar
@@ -163,6 +163,8 @@ make test
 make typecheck
 make lint
 ```
+Para um lint rápido apenas nos arquivos modificados, utilize `pre-commit run --files <arquivos_modificados>`.
+
 - Meta de cobertura: **≥ 80% (alerta se abaixo)**
 - Estilo: **ruff + black**
 - Tipagem: **mypy (strict)**
@@ -182,7 +184,7 @@ make lint
 - [ ] M11 - Documentação e Guias
 - [ ] M12 - Validação Final do MVP
 
-> Para detalhes, veja [Agents.md](Agents.md).
+> Para detalhes, veja [AGENTS.md](AGENTS.md).
 
 ## Stack Tecnológica
 Confira [TECH_STACK.md](TECH_STACK.md).

--- a/gen-agents.ps1
+++ b/gen-agents.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$Repo   = "leotavo/swing-trade-b3",
-  [string]$Out    = ".\Agents.md",
+  [string]$Out    = ".\AGENTS.md",
   [int]   $Limit  = 1000,   # máx. issues a buscar
   [string]$State  = "all"   # open | closed | all
 )
@@ -87,9 +87,9 @@ $issuesOrdered = $issues | Sort-Object `
   @{Expression={ [array]::IndexOf($MilestoneOrder, $_.milestone) }}, `
   number
 
-# ====== 3) Gerar Agents.md ======
+# ====== 3) Gerar AGENTS.md ======
 $sb = New-Object System.Text.StringBuilder
-$null = $sb.AppendLine("# Agents.md - Swing Trade B3")
+$null = $sb.AppendLine("# AGENTS.md - Swing Trade B3")
 $null = $sb.AppendLine()
 $null = $sb.AppendLine("Gerado automaticamente a partir de **milestones** e **issues** do repositório $Repo.")
 $null = $sb.AppendLine("> Estado: **$State** · Limite: **$Limit** · Gerado em: $(Get-Date -Format 'yyyy-MM-dd HH:mm') (America/Bahia)")


### PR DESCRIPTION
## Summary
- rename instructions file to AGENTS.md
- update references in README and generator script

## Testing
- `pre-commit run --files AGENTS.md README.md gen-agents.ps1`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b34149e8108326a6ee2faeada7dd50