### PR TITLE
docs: instrução para renomear branch antes do PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 > **Instrução:** Sempre que o projeto for atualizado, revise e atualize o README.md para refletir as mudanças.
 > **Branches:** Devem começar com `feat/`, `fix/` ou `docs/`; a verificação acontece no CI e falhará para nomes inválidos. O Codex também deve usar esses prefixos ao criar branches.
+> **Antes do PR:** Renomeie a branch para seguir o padrão, se necessário.
 
 Gerado automaticamente a partir de **milestones** e **issues** do repositório leotavo/swing-trade-b3.
 > Estado: **all** · Limite: **1000** · Gerado em: 2025-08-30 04:09 (America/Bahia)

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Confira [TECH_STACK.md](TECH_STACK.md).
 ## Contribuindo
 Leia o [CONTRIBUTING.md](CONTRIBUTING.md) e siga _Conventional Commits_.
 PRs com testes e atualização de docs quando aplicável.
-Branches devem seguir `feat/`, `fix/` ou `docs/` e são verificadas automaticamente no CI.
+Branches devem seguir `feat/`, `fix/` ou `docs/` e são verificadas automaticamente no CI. Antes de abrir o PR, renomeie a branch para seguir esse padrão.
 Se o workflow falhar devido ao nome, renomeie a branch para começar com um dos prefixos permitidos (ex.: `fix/codex-add-branch-name-validation-workflow`).
 
 ## Comunidade e Suporte


### PR DESCRIPTION
## Summary
- orientar renomear a branch para o padrão antes de abrir o PR
- incluir a mesma orientação no README

## Testing
- `pre-commit run --files AGENTS.md README.md`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b35e9b466c83268b79cf4aff58dac6