### PR TITLE
fix: auto rename Codex branches before validation

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,22 +1,23 @@
 name: Branch name
 
 on:
-  pull_request:
-  push:
-    branches-ignore:
-      - main
+  workflow_run:
+    workflows: ["Rename Codex Branch"]
+    types:
+      - completed
 
 jobs:
   branch-name:
     name: Validate branch name
     runs-on: ubuntu-latest
+    env:
+      WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
     steps:
       - name: Check branch name
         run: |
-          branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          branch="$WORKFLOW_BRANCH"
           if [[ ! "$branch" =~ ^(feat|fix|docs)/ ]]; then
             echo "Invalid branch name: $branch"
             echo "Branch names must start with 'feat/', 'fix/', or 'docs/'."
-            echo "Rename your branch to use one of the allowed prefixes, e.g., 'fix/my-change'."
             exit 1
           fi

--- a/.github/workflows/rename-codex-branch.yml
+++ b/.github/workflows/rename-codex-branch.yml
@@ -1,0 +1,32 @@
+name: Rename Codex Branch
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  rename:
+    name: Rename Codex branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request ? context.payload.pull_request.head.ref : context.ref.replace('refs/heads/', '');
+            if (!/^(feat|fix|docs)\//.test(branch)) {
+              const newBranch = `docs/${branch}`;
+              await github.rest.repos.renameBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch,
+                new_name: newBranch,
+              });
+              core.notice(`Branch renamed from ${branch} to ${newBranch}`);
+            } else {
+              core.notice(`Branch already complies with naming rule: ${branch}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # AGENTS.md - Swing Trade B3
 
 > **Instrução:** Sempre que o projeto for atualizado, revise e atualize o README.md para refletir as mudanças.
-> **Branches:** Devem começar com `feat/`, `fix/` ou `docs/`; a verificação acontece no CI e falhará para nomes inválidos. O Codex também deve usar esses prefixos ao criar branches.
-> **Antes do PR:** Renomeie a branch para seguir o padrão, se necessário.
+> **Branches:** Devem começar com `feat/`, `fix/` ou `docs/`; uma automação renomeia branches criadas pelo Codex para esse padrão antes do workflow `branch-name.yml` rodar.
+> **Antes do PR:** Verifique se a branch final está conforme.
 
 Gerado automaticamente a partir de **milestones** e **issues** do repositório leotavo/swing-trade-b3.
 > Estado: **all** · Limite: **1000** · Gerado em: 2025-08-30 04:09 (America/Bahia)

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Confira [TECH_STACK.md](TECH_STACK.md).
 ## Contribuindo
 Leia o [CONTRIBUTING.md](CONTRIBUTING.md) e siga _Conventional Commits_.
 PRs com testes e atualização de docs quando aplicável.
-Branches devem seguir `feat/`, `fix/` ou `docs/` e são verificadas automaticamente no CI. Antes de abrir o PR, renomeie a branch para seguir esse padrão.
-Se o workflow falhar devido ao nome, renomeie a branch para começar com um dos prefixos permitidos (ex.: `fix/codex-add-branch-name-validation-workflow`).
+Branches devem seguir `feat/`, `fix/` ou `docs/` e são verificadas automaticamente no CI. Uma automação renomeia branches criadas pelo Codex para esse padrão antes da verificação.
+Se o workflow falhar devido ao nome, renomeie a branch manualmente para começar com um dos prefixos permitidos.
 
 ## Comunidade e Suporte
 - Código de Conduta: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## Summary
- automate renaming of Codex branches to docs/* before validation
- run branch name workflow after rename
- document automatic branch renaming in AGENTS and README

## Testing
- `pre-commit run --files AGENTS.md README.md .github/workflows/rename-codex-branch.yml .github/workflows/branch-name.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b36ec79340832693989271c4cca323