### PR TITLE
fix: stabilize branch auto-rename workflow

### DIFF
--- a/.github/workflows/auto-rename-branch.yml
+++ b/.github/workflows/auto-rename-branch.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   rename:
-    if: ${{ !startsWith(github.ref_name, 'feat/') && !startsWith(github.ref_name, 'fix/') && !startsWith(github.ref_name, 'docs/') }}
+    if: ${{ !startsWith(github.ref_name, 'feat/') && !startsWith(github.ref_name, 'fix/') && !startsWith(github.ref_name, format('docs{0}', '/')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Rename branch to match naming convention
@@ -21,5 +21,15 @@ jobs:
             const newName = `feat/${oldName}`;
             const { owner, repo } = context.repo;
             const sha = context.sha;
-            await github.git.createRef({ owner, repo, ref: `refs/heads/${newName}`, sha });
-            await github.git.deleteRef({ owner, repo, ref: `heads/${oldName}` });
+            try {
+              await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${newName}`, sha });
+              await github.rest.git.deleteRef({ owner, repo, ref: `heads/${oldName}` });
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning(`Skipping branch rename: ${error.message}`);
+              } else if (error.status === 422) {
+                core.info('Branch already exists or could not be deleted; skipping rename.');
+              } else {
+                throw error;
+              }
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-          poetry --version
+          ~/.local/bin/poetry --version
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: poetry install --with dev
       - name: Ruff and Black
@@ -36,7 +37,8 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-          poetry --version
+          ~/.local/bin/poetry --version
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: poetry install --with dev
       - name: Mypy
@@ -53,7 +55,8 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-          poetry --version
+          ~/.local/bin/poetry --version
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: poetry install --with dev
       - name: Pytest

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ MILESTONES_ISSUES.csv
 *.sqlite3
 *.db
 *.db-*
+*.db-shm
+*.db-wal
+*.db-journal
 *.parquet
 *.feather
 *.pkl

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ curl -I http://localhost:8000/metrics | head -n 1
 - [Roadmap](#roadmap)
 - [Stack Tecnológica](#stack-tecnológica)
 - [Contribuindo](#contribuindo)
+  - [Convenção de Branches](#convenção-de-branches)
 - [Comunidade e Suporte](#comunidade-e-suporte)
 - [Licença](#licença)
 - [Aviso Legal](#aviso-legal)
@@ -190,10 +191,12 @@ Para um lint rápido apenas nos arquivos modificados, utilize `pre-commit run --
 Confira [TECH_STACK.md](TECH_STACK.md).
 
 ## Contribuindo
-Leia o [CONTRIBUTING.md](CONTRIBUTING.md) e siga _Conventional Commits_.
-PRs com testes e atualização de docs quando aplicável.
-Branches devem seguir `feat/`, `fix/` ou `docs/` e são verificadas automaticamente no CI. Antes de abrir o PR, renomeie a branch para seguir esse padrão. Um workflow renomeia automaticamente branches criadas pelo Codex para esse padrão antes da validação.
-Se o workflow falhar devido ao nome, renomeie a branch para começar com um dos prefixos permitidos (ex.: `fix/codex-add-branch-name-validation-workflow`).
+Leia o [CONTRIBUTING.md](CONTRIBUTING.md) e siga _Conventional Commits_. PRs com testes e atualização de docs quando aplicável.
+
+### Convenção de Branches
+Use os prefixos `feat/`, `fix/` ou `docs/` ao criar novas branches. O CI valida esse padrão e um workflow renomeia automaticamente branches criadas pelo Codex antes da verificação. Renomeie manualmente se necessário; se o token do workflow não tiver permissão (como em forks), o rename será ignorado.
+
+> O repositório inclui um `.gitignore` cobrindo Python, IDEs e dados brutos para evitar commits acidentais.
 
 ## Comunidade e Suporte
 - Código de Conduta: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
@@ -208,9 +211,8 @@ MIT — veja [LICENSE](LICENSE).
 Projeto **educacional**. Não constitui recomendação de investimento. Os autores não se responsabilizam por perdas financeiras.
 
 ## Troubleshooting Rápido
-- **Poetry não encontrado**: `pipx install poetry` ou docs oficiais.
+- **Poetry não encontrado**: `pipx install poetry` e garanta que `$HOME/.local/bin` esteja no `PATH` ou consulte a documentação oficial.
 - **Porta 8000 ocupada**: `make dev PORT=8001` e acesse `http://localhost:8001`.
 - **Windows/PowerShell**: use `curl` do Git ou `iwr/irm`.
 - **.env**: mantenha na raiz e reinicie o servidor após alterações.
 
-<!-- Teste de verificação de branch -->


### PR DESCRIPTION
## Summary
- expand gitignore with SQLite auxiliary files
- clean up README and note branch naming
- fix branch auto-rename workflow to use GitHub REST API and handle docs prefix
- ensure Poetry is available in CI by adding `$HOME/.local/bin` to the path
- skip auto-rename when the workflow token lacks permission

## Testing
- `make lint`
- `poetry run mypy .`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b371cfd7a4832680212624b2a08fcd