### PR TITLE
fix: ajustar .gitignore e idioma padrão

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Desktop.ini
 
 # Jupyter
 .ipynb_checkpoints/
+*.ipynb
 
 # Keys / secrets (prevent accidental commits)
 id_rsa*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 > **Branches:** Devem começar com `feat/`, `fix/` ou `docs/`; a verificação acontece no CI e falhará para nomes inválidos. O Codex também deve usar esses prefixos ao criar branches.
 > **Automação:** Branches criadas pelo Codex são renomeadas automaticamente para seguir essa regra antes da execução do workflow `branch-name`.
 > **Antes do PR:** Renomeie a branch para seguir o padrão, se necessário.
+> **Idioma:** Responda aos usuários sempre em português.
 
 Gerado automaticamente a partir de **milestones** e **issues** do repositório leotavo/swing-trade-b3.
 > Estado: **all** · Limite: **1000** · Gerado em: 2025-08-30 04:09 (America/Bahia)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 [![GitHub Release](https://img.shields.io/github/v/release/leotavo/swing-trade-b3?include_prereleases)](https://github.com/leotavo/swing-trade-b3/releases)
 [![Roadmap](https://img.shields.io/badge/roadmap-Milestones-blue)](https://github.com/leotavo/swing-trade-b3/milestones)
 
-> **Resumo**  
+> **Resumo**
 > Agente para automatizar Swing Trade na B3 com dados históricos, indicadores técnicos, backtesting e API REST para integração.
+> O idioma padrão do projeto é o português.
 
 ## TL;DR (Resumo rápido)
 


### PR DESCRIPTION
## Summary
- adiciona `*.ipynb` ao `.gitignore`
- define o português como idioma padrão nas interações

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b3b5e3966883268e5a038da3af87e4