### PR TITLE
fix: corrigir workflows do GitHub

### DIFF
--- a/.github/workflows/auto-rename-branch.yml
+++ b/.github/workflows/auto-rename-branch.yml
@@ -21,5 +21,5 @@ jobs:
             const newName = `feat/${oldName}`;
             const { owner, repo } = context.repo;
             const sha = context.sha;
-            await github.git.createRef({ owner, repo, ref: `refs/heads/${newName}`, sha });
-            await github.git.deleteRef({ owner, repo, ref: `heads/${oldName}` });
+            await github.rest.git.createRef({ owner, repo, ref: `refs/heads/${newName}`, sha });
+            await github.rest.git.deleteRef({ owner, repo, ref: `heads/${oldName}` });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
       - name: Install Poetry
         run: |
           pipx install poetry
           poetry --version
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'poetry'
       - name: Install dependencies
         run: poetry install --with dev
       - name: Ruff and Black
@@ -29,14 +29,14 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
       - name: Install Poetry
         run: |
           pipx install poetry
           poetry --version
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'poetry'
       - name: Install dependencies
         run: poetry install --with dev
       - name: Mypy
@@ -46,14 +46,14 @@ jobs:
     needs: typecheck
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'poetry'
       - name: Install Poetry
         run: |
           pipx install poetry
           poetry --version
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'poetry'
       - name: Install dependencies
         run: poetry install --with dev
       - name: Pytest

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ flowchart LR
 
 ### Pré-requisitos
 - [Python 3.11](https://www.python.org/)
-- [Poetry](https://python-poetry.org/) instalado e no PATH
+ - [Poetry](https://python-poetry.org/) instalado e no PATH (`pipx install poetry` se necessário; o CI usa o mesmo método)
 
 ### Instalação
 ```bash
@@ -209,7 +209,7 @@ MIT — veja [LICENSE](LICENSE).
 Projeto **educacional**. Não constitui recomendação de investimento. Os autores não se responsabilizam por perdas financeiras.
 
 ## Troubleshooting Rápido
-- **Poetry não encontrado**: `pipx install poetry` ou docs oficiais.
+- **Poetry não encontrado**: `pipx install poetry` (mesmo método usado no CI) ou docs oficiais.
 - **Porta 8000 ocupada**: `make dev PORT=8001` e acesse `http://localhost:8001`.
 - **Windows/PowerShell**: use `curl` do Git ou `iwr/irm`.
 - **.env**: mantenha na raiz e reinicie o servidor após alterações.


### PR DESCRIPTION
## Summary
- evitar erro de referência ao renomear branches
- instalar Poetry antes do setup-python na CI
- documentar uso de `pipx install poetry`

## Testing
- `pre-commit run --files .github/workflows/auto-rename-branch.yml .github/workflows/ci.yml README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3b7a6706083269f4efb86e3169d43