### PR TITLE
docs(release): publicar resumo do Milestone M1

### DIFF
--- a/docs/releases/m1-summary.md
+++ b/docs/releases/m1-summary.md
@@ -19,3 +19,9 @@
 - Releases: `docs/releases/v0.1.0.md`, `docs/releases/v0.2.0.md`, `docs/releases/v0.3.0.md`
 - Roadmap: `docs/MILESTONES_ISSUES.md`
 - Fluxo de Git: `docs/git-flow.md` e `CONTRIBUTING.md`
+
+## Links rápidos
+
+- GitHub Release v0.1.0: https://github.com/leotavo/swing-trade-b3/releases/tag/v0.1.0
+- GitHub Release v0.2.0: https://github.com/leotavo/swing-trade-b3/releases/tag/v0.2.0
+- GitHub Release v0.3.0: https://github.com/leotavo/swing-trade-b3/releases/tag/v0.3.0


### PR DESCRIPTION
Este PR publica e destaca o resumo do Milestone M1 (Configuração Inicial).

- Arquivo: docs/releases/m1-summary.md
- Conteúdo: escopo entregue, links para v0.1.0, v0.2.0, v0.3.0, roadmap e fluxo de Git
- Ajuste incluído: seção de Links rápidos para Releases do GitHub

Objetivo: dar visibilidade ao fechamento do M1 e servir de referência para próximos milestones.