### PR TITLE
chore(repo): normalize EOLs and add style guidelines (PT-BR docs, EN identifiers)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,6 +10,8 @@ assignees: ''
 
 Explique o bug de forma clara e concisa.
 
+Observação: explique em português; mantenha nomes de funções/variáveis/identificadores em inglês ao referenciar código.
+
 ## Passos para reproduzir
 
 1.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -10,6 +10,8 @@ assignees: ''
 
 Explique a necessidade e o objetivo da funcionalidade.
 
+Observação: explique em português; mantenha nomes de funções/variáveis/identificadores em inglês ao propor mudanças de código.
+
 ## Escopo
 
 Pontos principais do que deve ser feito.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Closes #<número-da-issue>
 - [ ] Lint/Format/Typecheck/Testes passaram localmente
 - [ ] Atualizei docs/README quando necessário
 - [ ] Alterações pequenas e focadas (< 300 linhas)
+- [ ] Expliquei e documentei em português; mantive nomes de funções/variáveis em inglês
 
 ## Riscos e mitigação
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ Exemplos
 - `test(data): cobrir limpeza de nulos`
 - `chore(pre-commit): atualizar hooks`
 
+## Padrões de código e qualidade
+
+- Use tipagem sempre que possível (mypy habilitado).
+- Siga o formato/lint definidos (black/ruff).
+- Escreva testes quando tocar em lógica não trivial.
+
+### Idioma e estilo
+
+- Explique e documente em português (pt‑BR): descrições de PRs, issues, comentários em docs.
+- Mantenha nomes de funções, variáveis, classes e identificadores em inglês no código.
+- Mensagens de commit seguem Conventional Commits; o texto pode ser em português.
+
 ## Dicas
 
 - Atualize a branch com `rebase` para manter o histórico limpo.

--- a/README.md
+++ b/README.md
@@ -226,5 +226,11 @@ jq -r 'select(.logger=="app.connector.b3" and (.message|test("429")))' logs/fetc
 
 Observação (PowerShell): use aspas duplas e escape `"` conforme necessário.
 
+## Padrões de Estilo
+
+- Idioma: explique e documente em português (pt‑BR); mantenha nomes de funções, variáveis e identificadores em inglês.
+- Commits: Conventional Commits (ex.: `feat:`, `fix:`, `docs:`, `chore:`). Mensagens podem ser em português; escopo/código permanecem em inglês.
+- Código: siga tipagem e lint configurados (ruff, black, mypy) e priorize nomes claros em inglês.
+
 Veja também um exemplo completo em:
 - docs/summary-example.json


### PR DESCRIPTION
This PR groups repository hygiene changes:

- Add `.gitattributes` to normalize line endings (prefer LF), keeping Windows script extensions with CRLF and binaries marked as `-text`.
- Bump releases already handled separately (v0.5.0 published), this PR contains no code behavior changes.
- Add style guidelines:
  - README: “Padrões de Estilo” (docs in pt-BR; identifiers in EN; Conventional Commits)
  - CONTRIBUTING: “Padrões de código e qualidade” + “Idioma e estilo”
  - PR/Issue templates: checklist/observações sobre idioma/identificadores

Notes
- No functional code changes; tests remain green locally.
- Future diffs should be stable across platforms due to normalized EOLs.