### PR TITLE
chore: add markdownlint docs + link

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "markdownlint:recommended",
+  "default": true,
   "MD013": false,
   "MD033": false,
   "MD041": false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - Esquema de dados: `docs/data-schema.md`
 - Fluxo de Git: `docs/git-flow.md`
 - Tech Stack: `docs/TECH_STACK.md`
+- Guia do Markdownlint: `docs/markdownlint.md`
 
 ## Ambiente de desenvolvimento
 

--- a/docs/markdownlint.md
+++ b/docs/markdownlint.md
@@ -1,0 +1,45 @@
+# Markdownlint — Guia de Uso
+
+Este projeto usa o markdownlint para padronizar Markdown em documentos e README.
+
+## Regras ativas
+
+- Base: `markdownlint:recommended` (via `.markdownlint.json`).
+- Desativadas por contexto do projeto:
+  - MD013: comprimento de linha (desativada para facilitar diffs e URLs longas).
+  - MD033: HTML em Markdown (permitimos casos pontuais).
+  - MD041: heading de nível 1 no início do arquivo (não exigido em todos os docs).
+
+## Regras comuns no repositório
+
+- MD040: sempre especifique a linguagem em blocos de código (ex.: `bash`, `json`, `text`).
+- MD022: deixe 1 linha em branco antes/depois de títulos (#, ##, ...).
+- MD032: deixe 1 linha em branco antes/depois de listas (-, *, 1.).
+
+## Como executar localmente
+
+Pré-requisito: Node.js 18+.
+
+```bash
+npx markdownlint-cli "**/*.md" --config .markdownlint.json
+```
+
+## Pre-commit
+
+Há um hook configurado em `.pre-commit-config.yaml`.
+
+Instalar hooks:
+
+```bash
+pre-commit install
+```
+
+Checar todo o repositório:
+
+```bash
+pre-commit run markdownlint --all-files
+```
+
+## CI
+
+O GitHub Actions roda um job `markdownlint` em `.github/workflows/ci.yml` usando `markdownlint-cli`.


### PR DESCRIPTION
Resumo
- PR documenta o uso do markdownlint (regras, pre-commit e CI) e adiciona link no README.

Mudanças
- docs/markdownlint.md: guia de regras e como rodar
- README.md: link para o guia na seção Documentação

Contexto
- Configuração, hook de pre-commit e job do CI já foram adicionados à main nos commits anteriores.

Como testar
- npx markdownlint-cli "**/*.md" --config .markdownlint.json
- pre-commit run markdownlint --all-files